### PR TITLE
Only fetch from specified repo

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -1,1 +1,1 @@
-gem fetch $INPUT_GEM_NAME -s $INPUT_GEM_REPOSITORY && ls *.gem >/dev/null
+gem fetch $INPUT_GEM_NAME --clear-sources -s $INPUT_GEM_REPOSITORY && ls *.gem >/dev/null


### PR DESCRIPTION
Otherwise, the action falls back to fetching from rubygems.org, and auth failures are ignored.