### PR TITLE
Use `GITHUB_REPOSITORY_OWNER` instead of `GITHUB_ACTOR`

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -2,7 +2,7 @@ mkdir -p ~/.gem
 echo ":github: Bearer $GITHUB_TOKEN" > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials
 
-output=`gem push --k github --host "https://rubygems.pkg.github.com/$GITHUB_ACTOR" *.gem`
+output=`gem push --k github --host "https://rubygems.pkg.github.com/$GITHUB_REPOSITORY_OWNER" *.gem`
 
 if [ $? -eq 0 ] || [ `echo $output | grep -c 'already been pushed'` -eq 1 ]; then
   echo $output


### PR DESCRIPTION
Github actor is the user that triggered the workflow, which may or may not be the same as the repository owner.
And it seems Github changed who's the actor of workflows triggered on a schedule.

Test workflow still works: https://github.com/henriquehirako?tab=packages
